### PR TITLE
Python action update

### DIFF
--- a/build/pypi/Dockerfile
+++ b/build/pypi/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.8-slim-buster as runtime
 LABEL "maintainer"="Metroscope"
 
-RUN pip3 install setuptools wheel twine
+RUN pip3 install -U pip
+RUN pip3 install "setuptools~=53.0.0" "wheel~=0.36.2" "twine~=3.3.0"
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/pypi/entrypoint.sh
+++ b/build/pypi/entrypoint.sh
@@ -16,10 +16,6 @@ if [ ${version_already_on_remote_repo} = 1 ]; then
     exit 1
 fi
 
-echo "=> Update pip and install build dependencies"
-pip3 install -U pip
-pip3 install "setuptools>=53.0.0" "wheel>=0.36.2"
-
 echo "=> Install local package"
 pip3 install \
      --index-url https://${INPUT_JFROG_USERNAME}:${INPUT_JFROG_PASSWORD}@metroscope.jfrog.io/metroscope/api/pypi/python-repo/simple \

--- a/build/pypi/entrypoint.sh
+++ b/build/pypi/entrypoint.sh
@@ -5,7 +5,6 @@ PACKAGE_VERSION=${INPUT_PACKAGE_VERSION##*/}
 PACKAGE_NAME=$(python3 setup.py --name)
 
 echo "=> Build and push $PACKAGE_NAME==$PACKAGE_VERSION"
-sed -i "s/version=.*/version='$PACKAGE_VERSION',/g" setup.py
 
 echo "=> Check if $PACKAGE_NAME==$PACKAGE_VERSION"
 version_already_on_remote_repo=$(pip3 install --index-url https://${INPUT_JFROG_USERNAME}:${INPUT_JFROG_PASSWORD}@metroscope.jfrog.io/metroscope/api/pypi/python-repo/simple ${PACKAGE_NAME}==notexisting 2>&1 | grep "Could not find a version that satisfies the requirement" | grep "[^0-9.]${PACKAGE_VERSION}[^0-9.]" | wc -l)
@@ -17,15 +16,20 @@ if [ ${version_already_on_remote_repo} = 1 ]; then
     exit 1
 fi
 
+echo "=> Update pip and install build dependencies"
+pip3 install -U pip
+pip3 install setuptools>=53.0.0 wheel>=0.36.2
+
 echo "=> Install local package"
 pip3 install \
      --index-url https://${INPUT_JFROG_USERNAME}:${INPUT_JFROG_PASSWORD}@metroscope.jfrog.io/metroscope/api/pypi/python-repo/simple \
      --extra-index-url https://pypi.python.org/simple .
+
 echo "=> Create all-requirements.txt"
-pip3 list --format=freeze > all-requirements.txt
+pip3 freeze --all > all-requirements.txt
 
 echo "=> Build $PACKAGE_NAME==$PACKAGE_VERSION"
 python3 setup.py sdist bdist_wheel
 
 echo "=> Build $PACKAGE_NAME==$PACKAGE_VERSION"
-twine upload --repository-url https://metroscope.jfrog.io/metroscope/api/pypi/python-repo/ --username ${INPUT_JFROG_USERNAME} --password ${INPUT_JFROG_PASSWORD} dist/*.tar.gz
+twine upload --repository-url https://metroscope.jfrog.io/metroscope/api/pypi/python-repo/ --username ${INPUT_JFROG_USERNAME} --password ${INPUT_JFROG_PASSWORD} dist/*

--- a/build/pypi/entrypoint.sh
+++ b/build/pypi/entrypoint.sh
@@ -26,7 +26,7 @@ pip3 install \
      --extra-index-url https://pypi.python.org/simple .
 
 echo "=> Create all-requirements.txt"
-pip3 freeze --all > all-requirements.txt
+pip3 list --format=freeze > all-requirements.txt
 
 echo "=> Build $PACKAGE_NAME==$PACKAGE_VERSION"
 python3 setup.py sdist bdist_wheel

--- a/build/pypi/entrypoint.sh
+++ b/build/pypi/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 
 echo "=> Update pip and install build dependencies"
 pip3 install -U pip
-pip3 install setuptools>=53.0.0 wheel>=0.36.2
+pip3 install "setuptools>=53.0.0" "wheel>=0.36.2"
 
 echo "=> Install local package"
 pip3 install \


### PR DESCRIPTION
**Goal**
Help fix and update the centralized PyPi release action

**Changes**
- removed inplace version update in the `setup.py`
-> it was hardcoded
-> setup.py will not stay forever
-> this meant `master` was not up to date after the tag/release

- Upgraded pip and specified compatible versions of `setuptools`, `wheel` and `twine` in the Dockefile

- Replaced upload file types `dist\*.tar.gz` to `dist\*` to include wheels and not only source distribution
